### PR TITLE
Extract vm-cpu chart logic to Angular controllers

### DIFF
--- a/src/vm-cpu/vm-cpu-donut-chart-controller.js
+++ b/src/vm-cpu/vm-cpu-donut-chart-controller.js
@@ -1,4 +1,4 @@
-angular.module('apf.vmCpuModule').controller('vmCpuDonutChartController',[function () {
+angular.module('apf.vmCpuModule').controller('vmCpuDonutChartController', [function VmCpuDonutChartController() {
   'use strict';
   var donutConfig = $().c3ChartDefaults().getDefaultDonutConfig('A');
   donutConfig.bindto = '#chart-pf-donut-1';

--- a/src/vm-cpu/vm-cpu-donut-chart-controller.js
+++ b/src/vm-cpu/vm-cpu-donut-chart-controller.js
@@ -1,0 +1,32 @@
+angular.module('apf.vmCpuModule').controller('vmCpuDonutChartController',[function () {
+  'use strict';
+  var donutConfig = $().c3ChartDefaults().getDefaultDonutConfig('A');
+  donutConfig.bindto = '#chart-pf-donut-1';
+  donutConfig.color =  {
+    pattern: ["#cc0000","#D1D1D1"]
+  };
+  donutConfig.data = {
+    type: "donut",
+    columns: [
+      ["Used", 95],
+      ["Available", 5]
+    ],
+    groups: [
+      ["used", "available"]
+    ],
+    order: null
+  };
+  donutConfig.tooltip = {
+    contents: function (d) {
+      return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
+        Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+        '</span>';
+    }
+  };
+
+  var chart1 = c3.generate(donutConfig);
+  var donutChartTitle = d3.select("#chart-pf-donut-1").select('text.c3-chart-arcs-title');
+  donutChartTitle.text("");
+  donutChartTitle.insert('tspan').text("950").classed('donut-title-big-pf', true).attr('dy', 0).attr('x', 0);
+  donutChartTitle.insert('tspan').text("MHz Used").classed('donut-title-small-pf', true).attr('dy', 20).attr('x', 0);
+}]);

--- a/src/vm-cpu/vm-cpu-sparkline-chart-controller.js
+++ b/src/vm-cpu/vm-cpu-sparkline-chart-controller.js
@@ -1,4 +1,4 @@
-angular.module('apf.vmCpuModule').controller('vmCpuSparklineChartController',[function () {
+angular.module('apf.vmCpuModule').controller('vmCpuSparklineChartController', [function VmCpuSparklineChartController() {
   'use strict';
   var sparklineConfig = $().c3ChartDefaults().getDefaultSparklineConfig();
   sparklineConfig.bindto = '#chart-pf-sparkline-1';

--- a/src/vm-cpu/vm-cpu-sparkline-chart-controller.js
+++ b/src/vm-cpu/vm-cpu-sparkline-chart-controller.js
@@ -1,0 +1,13 @@
+angular.module('apf.vmCpuModule').controller('vmCpuSparklineChartController',[function () {
+  'use strict';
+  var sparklineConfig = $().c3ChartDefaults().getDefaultSparklineConfig();
+  sparklineConfig.bindto = '#chart-pf-sparkline-1';
+  sparklineConfig.data = {
+    columns: [
+      ['%', 10, 50, 28, 20, 31, 27, 60, 36, 52, 55, 62, 68, 69, 88, 74, 88, 95],
+    ],
+    type: 'area'
+  };
+  var chart2 = c3.generate(sparklineConfig);
+}]);
+

--- a/src/vm-cpu/vm-cpu.html
+++ b/src/vm-cpu/vm-cpu.html
@@ -39,49 +39,8 @@
               <span class="card-pf-utilization-card-details-line-2">of 1000 MHz</span>
             </span>
               </p>
-              <div id="chart-pf-donut-1"></div>
-              <div class="chart-pf-sparkline" id="chart-pf-sparkline-1"></div>
-              <script>
-                var donutConfig = $().c3ChartDefaults().getDefaultDonutConfig('A');
-                donutConfig.bindto = '#chart-pf-donut-1';
-                donutConfig.color =  {
-                  pattern: ["#cc0000","#D1D1D1"]
-                };
-                donutConfig.data = {
-                  type: "donut",
-                  columns: [
-                    ["Used", 95],
-                    ["Available", 5]
-                  ],
-                  groups: [
-                    ["used", "available"]
-                  ],
-                  order: null
-                };
-                donutConfig.tooltip = {
-                  contents: function (d) {
-                    return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                      Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
-                      '</span>';
-                  }
-                };
-
-                var chart1 = c3.generate(donutConfig);
-                var donutChartTitle = d3.select("#chart-pf-donut-1").select('text.c3-chart-arcs-title');
-                donutChartTitle.text("");
-                donutChartTitle.insert('tspan').text("950").classed('donut-title-big-pf', true).attr('dy', 0).attr('x', 0);
-                donutChartTitle.insert('tspan').text("MHz Used").classed('donut-title-small-pf', true).attr('dy', 20).attr('x', 0);
-
-                var sparklineConfig = $().c3ChartDefaults().getDefaultSparklineConfig();
-                sparklineConfig.bindto = '#chart-pf-sparkline-1';
-                sparklineConfig.data = {
-                  columns: [
-                    ['%', 10, 50, 28, 20, 31, 27, 60, 36, 52, 55, 62, 68, 69, 88, 74, 88, 95],
-                  ],
-                  type: 'area'
-                };
-                var chart2 = c3.generate(sparklineConfig);
-              </script>
+              <div id="chart-pf-donut-1" ng-controller="vmCpuDonutChartController"></div>
+              <div class="chart-pf-sparkline" id="chart-pf-sparkline-1" ng-controller="vmCpuSparklineChartController"></div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Extract donut and sparkline chart logic out of embedded <script> tags into Angular controllers.