### PR TITLE
Stub notificationService and vmOverviewController

### DIFF
--- a/src/app/app-module.js
+++ b/src/app/app-module.js
@@ -7,6 +7,9 @@ angular.module ('apf.appModule', [
   'patternfly.toolbars',
   'patternfly.charts',
 
+  // app-wide services
+  'apf.notificationsModule',
+
   // VM-related plugins
   'apf.vmOverviewModule',
   'apf.vmCpuModule',

--- a/src/app/notifications-module.js
+++ b/src/app/notifications-module.js
@@ -1,0 +1,2 @@
+angular
+  .module('apf.notificationsModule', []);

--- a/src/app/notifications-service.js
+++ b/src/app/notifications-service.js
@@ -1,0 +1,9 @@
+angular
+  .module('apf.notificationsModule')
+  .service('apf.notificationService', [
+    function () {
+      'use strict';
+      this.toggleNotificationDrawerHidden = function () {};
+      this.notificationGroups = [];
+    }
+  ]);

--- a/src/vm-overview/vm-overview-controller.js
+++ b/src/vm-overview/vm-overview-controller.js
@@ -1,1 +1,5 @@
-angular.module('apf.vmOverviewModule').controller('vmOverviewController', []);
+angular.module('apf.vmOverviewModule').controller('vmOverviewController', [
+  function () {
+    'use strict';
+  }
+]);


### PR DESCRIPTION
These two implementations are missing, which cause errors to be printed in the browser web console. Nothing appears to actually be broken, at least. These commits simply stub the implementations out with no-ops.